### PR TITLE
Fix: fixed printf can't format % character which following the percentage

### DIFF
--- a/.dwm/bar
+++ b/.dwm/bar
@@ -27,7 +27,7 @@ xbps_updates() {
 # battery
 batt() {
   printf "^c#81A1C1^  "
-  printf "^c#81A1C1^ $(acpi | sed "s/,//g" | awk '{if ($3 == "Discharging"){print $4; exit} else {print $4""}}' | tr -d "\n")"
+  printf "^c#81A1C1^ $(acpi | sed "s/,//g" | sed "s/%/%%/g" | awk '{if ($3 == "Discharging"){print $4; exit} else {print $4""}}' | tr -d "\n")"
 }
 
 brightness() {


### PR DESCRIPTION
The old script will generate an error: `bash: printf: `%': invalid format character`. This is because the printf method tries to format the '%' character. The PR replaced the single '%' character with '%%'.