### PR TITLE
fix: fixed tab bar total width calculate bug

### DIFF
--- a/chadwm/dwm.c
+++ b/chadwm/dwm.c
@@ -1521,6 +1521,7 @@ drawtab(Monitor *m) {
 	}
 
         if(tot_width > mw){ //not enough space to display the labels, they need to be truncated
+	  tot_width = 0; // recalculate total width of the tab bar
 	  memcpy(sorted_label_widths, m->tab_widths, sizeof(int) * m->ntabs);
 	  qsort(sorted_label_widths, m->ntabs, sizeof(int), cmpint);
 	  for(i = 0; i < m->ntabs; ++i){


### PR DESCRIPTION
The drawbar function should truncated bar width when the total width of the tab is longer than the max-width. But the for loop in the truncated step doesn't reset the total width variable. So the for loop will increase total width and the tab bar will never be truncated.