### PR TITLE
Update minor spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ eww open eww
 - cfacts
 - dragmfact 
 - dragcfact (took from [bakkeby's build](https://github.com/bakkeby/dwm-flexipatch))
-- fibonacii
+- fibonacci
 - gaplessgrid
 - horizgrid
 - movestack 


### PR DESCRIPTION
This should change the README's spelling of "fibonacii" to "fibonacci."